### PR TITLE
feat: 소셜커머스 크롤링 데이터 DB 저장 로직 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## 코딩 컨벤션
 - Front-End, Back-End 모두 JS 사용으로 컨벤션 통일
-- [Airbnb JavaScript Convention])(https://github.com/airbnb/javascript) 사용
+- [Airbnb JavaScript Convention](https://github.com/airbnb/javascript) 사용
 
 ### 사용 Tool
 - ESLint : JavaScript 코드에서 발견 된 문제을 식별하는 정적 코드 분석 도구

--- a/app.js
+++ b/app.js
@@ -4,8 +4,6 @@ const app = express();
 const { sequelize } = require('./models');
 const promotionRouter = require('./routes/promotionRouter.js');
 
-const app = express();
-
 app.use('/api', promotionRouter);
 
 sequelize.sync().then(() => {

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const express = require('express');
+
 const app = express();
 
 const { sequelize } = require('./models');
@@ -6,9 +7,7 @@ const promotionRouter = require('./routes/promotionRouter.js');
 const categoryRouter = require('./routes/categoryRouter.js');
 const brandRouter = require('./routes/brandRouter.js');
 
-app.use('/api', promotionRouter);
-app.use('/api', categoryRouter);
-app.use('/api', brandRouter);
+app.use('/api', [promotionRouter, categoryRouter, brandRouter]);
 
 sequelize.sync().then(() => {
   app.listen(8080);

--- a/crawler/clothes/eightSecondsCrawler.js
+++ b/crawler/clothes/eightSecondsCrawler.js
@@ -1,0 +1,57 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const BASE_URL =
+  'https://www.ssfshop.com/special/list?dspCtgryNo=PLAN&brandShopNo=BDMA07A01&brndShopId=8SBSS&etcCtgryNo=&ctgrySectCd=&keyword=&leftBrandNM=8SECONDS_8SBSS';
+
+const eightSecondsCrawler = (() => {
+  const getAll = async (page) => {
+    const promotions = await page.evaluate(() => {
+      const promotionList = Array.from(document.querySelectorAll('#list > li'));
+
+      return promotionList.map((dom) => {
+        const promotion = {};
+
+        promotion.url = dom.querySelector('a').getAttribute('href');
+
+        promotion.image = dom.querySelector('a >img').getAttribute('src');
+
+        promotion.title = dom.querySelector('a > div > span.title').textContent;
+
+        promotion.description = '';
+
+        return JSON.stringify(promotion);
+      });
+    });
+
+    return Promise.all(promotions);
+  };
+
+  const run = async () => {
+    let promotions = [];
+
+    try {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.goto(BASE_URL, { waitUnitl: 'networkidle0' });
+      await page.waitForSelector('#list > li');
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.log(e);
+    }
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const eightSecondsSaveAll = async () => {
+  const promotions = await eightSecondsCrawler.run();
+
+  await createAll(promotions);
+};
+
+module.exports = { eightSecondsSaveAll };

--- a/crawler/clothes/musinsaCrawler.js
+++ b/crawler/clothes/musinsaCrawler.js
@@ -1,9 +1,5 @@
 const puppeteer = require('puppeteer');
-<<<<<<< HEAD:crawler/clothes/musinsaCrawler.js
-const { bulkCreate } = require('../../service/promotionService.js');
-=======
 const { createAll } = require('../../service/promotionService.js');
->>>>>>> d58c608d6e01efc6477db30c4f1870793a8f9659:crawler/musinsaCrawler.js
 
 const BASE_URL = 'https://store.musinsa.com';
 

--- a/crawler/clothes/musinsaCrawler.js
+++ b/crawler/clothes/musinsaCrawler.js
@@ -1,5 +1,9 @@
 const puppeteer = require('puppeteer');
-const { bulkCreate } = require('../service/promotionService.js');
+<<<<<<< HEAD:crawler/clothes/musinsaCrawler.js
+const { bulkCreate } = require('../../service/promotionService.js');
+=======
+const { createAll } = require('../../service/promotionService.js');
+>>>>>>> d58c608d6e01efc6477db30c4f1870793a8f9659:crawler/musinsaCrawler.js
 
 const BASE_URL = 'https://store.musinsa.com';
 
@@ -81,10 +85,10 @@ const musinsaCrawler = async () => {
   return promotions;
 };
 
-const musinsaPromotionSaveAll = async () => {
+const musinsaSaveAll = async () => {
   const promotions = await musinsaCrawler();
 
-  await bulkCreate(promotions, 1);
+  await createAll(promotions, 1);
 };
 
-module.exports = { promotionSaveAll: musinsaPromotionSaveAll };
+module.exports = { musinsaSaveAll };

--- a/crawler/clothes/styleShareCrawler.js
+++ b/crawler/clothes/styleShareCrawler.js
@@ -1,0 +1,79 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const BASE_URL = 'https://www.styleshare.kr';
+
+const styleShareCrawler = (() => {
+  const getAll = async (page) => {
+    const promotions = await page.evaluate(() => {
+      const promotionList = Array.from(
+        document.querySelectorAll(
+          '#app > main > div > div.BannerContainer__StyledContainer-jygeOL.cWPmxb.store__banner > div.slick-slider.slick-initialized > div > div > div',
+        ),
+      );
+
+      return promotionList.map((dom) => {
+        const promotion = {};
+
+        promotion.url = dom.querySelector('div > div > a').getAttribute('href');
+
+        promotion.image = dom
+          .querySelector('div > div > a > picture > img')
+          .getAttribute('src');
+
+        promotion.title =
+          dom.querySelector(
+            'div > div > a > div > div.BannerDescription__StyledDescription-fnsujr',
+          ) === null
+            ? ''
+            : dom.querySelector(
+                'div > div > a > div > div.BannerDescription__StyledDescription-fnsujr',
+              ).textContent;
+
+        promotion.description =
+          dom.querySelector(
+            'div > div > a > div > div.BannerDescription__StyledSubDescription-ebdyxv',
+          ) === null
+            ? ''
+            : dom.querySelector(
+                'div > div > a > div > div.BannerDescription__StyledSubDescription-ebdyxv',
+              ).textContent;
+
+        return JSON.stringify(promotion);
+      });
+    });
+
+    return Promise.all(promotions);
+  };
+
+  const run = async () => {
+    let promotions = [];
+
+    try {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.goto(`${BASE_URL}/store`, { waitUnitl: 'networkidle0' });
+      await page.waitForSelector(
+        '#app > main > div > div.BannerContainer__StyledContainer-jygeOL.cWPmxb.store__banner > div.slick-slider.slick-initialized > div > div > div',
+      );
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.log(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const styleShareCrawlerSaveAll = async () => {
+  const promotions = await styleShareCrawler.run();
+
+  await createAll(promotions, 1);
+};
+
+module.exports = { styleShareCrawlerSaveAll };

--- a/crawler/socialCommerce/coupangCrawler.js
+++ b/crawler/socialCommerce/coupangCrawler.js
@@ -1,0 +1,76 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const URL = 'https://www.coupang.com/np/exhibition/ALL';
+
+const httpsPrefix = 'https:';
+const coupangSourceUrl = `${httpsPrefix}//www.coupang.com`;
+
+const getCompleteUrl = (url, type) => {
+  if (url.indexOf(httpsPrefix) === -1) {
+    if (type === 1) {
+      // type === 1 : 'PROMOTION'
+      return coupangSourceUrl + url;
+    }
+    // type === 2 : 'IMAGE'
+    return httpsPrefix + url;
+  }
+  return url;
+};
+
+const coupangCrawler = (() => {
+  const getAll = async (page) => {
+    // 기획전 목록 가져오기
+    const promotionList = await page.$$('ul#productList > li');
+
+    // 기획전 데이터 element를 JSON 형태로 가공
+    const scrappedData = [];
+    for (const promotion of promotionList) {
+      scrappedData.push(
+        JSON.stringify({
+          url: getCompleteUrl(
+            await promotion.$eval('a', (elem) => elem.getAttribute('href')),
+            1,
+          ),
+          image: getCompleteUrl(
+            await promotion.$eval('a > img', (elem) =>
+              elem.getAttribute('src'),
+            ),
+            2,
+          ),
+          title: 'untitled',
+          description: '',
+        }),
+      );
+    }
+    return Promise.all(scrappedData);
+  };
+
+  const run = async () => {
+    let promotions;
+
+    try {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.goto(URL);
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.error(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const coupangCrawlerSaveAll = async () => {
+  const promotions = await coupangCrawler.run();
+
+  await createAll(promotions, 5);
+};
+
+module.exports = { coupangCrawlerSaveAll };

--- a/crawler/socialCommerce/eleventhStreetCrawler.js
+++ b/crawler/socialCommerce/eleventhStreetCrawler.js
@@ -1,0 +1,123 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const categories = [
+  { index: '01', type: '브랜드패션 기획전' },
+  { index: '02', type: '의류 기획전' },
+  { index: '03', type: '잡화 기획전' },
+  { index: '04', type: '뷰티 기획전' },
+  { index: '05', type: '식품 기획전' },
+  { index: '06', type: '유아동 기획전' },
+  { index: '07', type: '가구 기획전' },
+  { index: '08', type: '생활용품 기획전' },
+  { index: '09', type: '레저/자동차 기획전' },
+  { index: '10', type: '디지털/가전 기획전' },
+  { index: '11', type: '도서/여행/취미 기획전' },
+  { index: '12', type: '해외직구 기획전' },
+  { index: '13', type: '홈&카서비스 기획전' },
+];
+
+const getUrl = (index, page) => {
+  return `https://www.11st.co.kr/plan/front/displays/${index}?pageNo=${page}`;
+};
+
+// 문자열에서 숫자를 추출하는 함수
+const getNumber = (method) => {
+  let num = '';
+  for (const ch of method) {
+    if (!isNaN(ch)) {
+      num += ch;
+    }
+  }
+  return Number(num);
+};
+
+const getCompleteUrl = (url) => {
+  return `http://www.11st.co.kr/${url}`;
+};
+
+const eleventhStreetCrawler = (() => {
+  const getAll = async (page) => {
+    const scrappedData = [];
+
+    // 카테고리 별 페이지 모두 탐색
+    for (const currCategory of categories) {
+      let currPageNum = 1;
+      const startUrl = getUrl(currCategory.index, currPageNum);
+      await page.goto(startUrl);
+
+      let lastPageNum; // 현재 카테고리가 여러 페이지로 구성되어 있을 경우 마지막 페이지 번호를 저장.
+      try {
+        // 여러 페이지일 경우
+        lastPageNum = getNumber(
+          await page.$eval(
+            '#layBody > div.product_list_box_v2 > div.s_paging > a.last',
+            (elem) => elem.getAttribute('onclick'),
+          ),
+        );
+      } catch (err) {
+        // 단일 페이지일 경우
+        lastPageNum = 1;
+      }
+
+      // 현재 카테고리의 모든 페이지를 순회하면서 데이터 수집
+      for (currPageNum = 1; currPageNum <= lastPageNum; currPageNum++) {
+        const URL = getUrl(currCategory.index, currPageNum);
+        await page.goto(URL);
+
+        const planList = await page.$$(
+          '#layBody > div.product_list_box_v2 > div.inner_box > ul.list_box > li',
+        );
+
+        for (const plan of planList) {
+          scrappedData.push(
+            JSON.stringify({
+              url: getCompleteUrl(
+                await plan.$eval('div.banner_box > h3 > a', (elem) =>
+                  elem.getAttribute('href'),
+                ),
+              ),
+              image: await plan.$eval('div.banner_box > h3 > a > img', (elem) =>
+                elem.getAttribute('src'),
+              ),
+              title: await plan.$eval('div.banner_box > h3 > a > img', (elem) =>
+                elem.getAttribute('alt'),
+              ),
+              description: currCategory.type,
+            }),
+          );
+        }
+      }
+    }
+    return Promise.all(scrappedData);
+  };
+
+  const run = async () => {
+    let promotions;
+
+    try {
+      const browser = await puppeteer.launch({
+        headless: false,
+      });
+      const page = await browser.newPage();
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.error(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const eleventhStreetCrawlerSaveAll = async () => {
+  const promotions = await eleventhStreetCrawler.run();
+
+  await createAll(promotions, 5);
+};
+
+module.exports = { eleventhStreetCrawlerSaveAll };

--- a/crawler/socialCommerce/eleventhStreetCrawler.js
+++ b/crawler/socialCommerce/eleventhStreetCrawler.js
@@ -96,9 +96,7 @@ const eleventhStreetCrawler = (() => {
     let promotions;
 
     try {
-      const browser = await puppeteer.launch({
-        headless: false,
-      });
+      const browser = await puppeteer.launch();
       const page = await browser.newPage();
 
       promotions = await getAll(page);

--- a/crawler/socialCommerce/gmarketCrawler.js
+++ b/crawler/socialCommerce/gmarketCrawler.js
@@ -1,0 +1,67 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const URL = 'https://www.gmarket.co.kr/';
+
+const gmarketCrawler = (() => {
+  const getAll = async (page) => {
+    // 기획전 페이지 보기('+' 버튼 클릭)
+    await page.$eval('button.button__more', (btn) => btn.click());
+
+    // 기획전 목록 가져오기
+    const promotionList = await page.$$(
+      'div.section__all-promotion > div > ul > li',
+    );
+
+    const scrappedData = [];
+
+    // 각 기획전 element에서 필요한 데이터 추출
+    for (const promotion of promotionList) {
+      scrappedData.push(
+        JSON.stringify({
+          url: await promotion.$eval('a', (elem) =>
+            elem.getAttribute('href'),
+          ),
+          image: await promotion.$eval('a > div > img', (elem) =>
+            elem.getAttribute('src'),
+          ),
+          title: await promotion.$eval('a > div > img', (elem) =>
+            elem.getAttribute('alt'),
+          ),
+          description: '',
+        }),
+      );
+    }
+    return Promise.all(scrappedData);
+  };
+
+  const run = async () => {
+    let promotions;
+
+    try {
+      const browser = await puppeteer.launch({
+        headless: false,
+      });
+      const page = await browser.newPage();
+      await page.goto(URL);
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.error(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const gmarketCrawlerSaveAll = async () => {
+  const promotions = await gmarketCrawler.run();
+
+  await createAll(promotions, 5);
+};
+
+module.exports = { gmarketCrawlerSaveAll };

--- a/crawler/socialCommerce/tmonCrawler.js
+++ b/crawler/socialCommerce/tmonCrawler.js
@@ -1,0 +1,82 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const URL = 'http://www.tmon.co.kr/planning/';
+
+// 스크롤에 반응하는 사이트에서 추가적인 데이터를 얻기 위해 autoScroll 메서드 생성
+const autoScroll = async (page) => {
+  await page.evaluate(async () => {
+    await new Promise((resolve, reject) => {
+      let totalHeight = 0;
+      const distance = 500; // 스크롤 1회당 간격
+      const timer = setInterval(() => {
+        const scrollHeight = document.body.scrollHeight;
+        window.scrollBy(0, distance);
+        totalHeight += distance;
+
+        if (totalHeight >= scrollHeight) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 100); // 스크롤 1회당 시간 간격
+    });
+  });
+};
+
+const tmonCrawler = (() => {
+  const getAll = async (page) => {
+    // 스크롤 가장 아래로 내려서 모든 데이터 로딩
+    await autoScroll(page);
+
+    const planList = await page.$$(
+      '#planWrap > div > div > div.plan_collect_box',
+    );
+
+    const scrappedData = [];
+    for (const plan of planList) {
+      scrappedData.push(
+        JSON.stringify({
+          url: await plan.$eval('div.plan_collect_banner > a', (elem) =>
+            elem.getAttribute('href'),
+          ),
+          image: await plan.$eval('div.plan_collect_banner > a > img', (elem) =>
+            elem.getAttribute('src'),
+          ),
+          title: await plan.$eval('div.plan_collect_banner > a > img', (elem) =>
+            elem.getAttribute('alt'),
+          ),
+          description: '',
+        }),
+      );
+    }
+    return Promise.all(scrappedData);
+  };
+
+  const run = async () => {
+    let promotions;
+
+    try {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.goto(URL);
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.error(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const tmonCrawlerSaveAll = async () => {
+  const promotions = await tmonCrawler.run();
+
+  await createAll(promotions, 5);
+};
+
+module.exports = { tmonCrawlerSaveAll };

--- a/crawler/socialCommerce/wemakepriceCrawler.js
+++ b/crawler/socialCommerce/wemakepriceCrawler.js
@@ -1,0 +1,78 @@
+const puppeteer = require('puppeteer');
+const { createAll } = require('../../service/promotionService.js');
+
+const httpsPrefix = 'https:';
+const URL = `${httpsPrefix}//front.wemakeprice.com/promotions/main`;
+
+const appendHttps = (url) => {
+  if (url.indexOf(httpsPrefix) === -1) {
+    // 접두사 'https:' 가 없는 URL일 경우
+    return httpsPrefix + url;
+  }
+  return url; // 정상적인 URL일 경우
+};
+
+const getTitle = (raw) => {
+  // RAW Data에서 필요한 값만 추출
+  return raw.substr(raw.indexOf('_') + 1);
+};
+
+const wemakepriceCrawler = (() => {
+  const getAll = async (page) => {
+    // 프로모션 페이지가 로딩될 때까지 대기
+    await page.waitForSelector('#_contents > div > div.promotion_list > ul');
+
+    const promotionList = await page.$$(
+      '#_contents > div > div.promotion_list > ul > li',
+    );
+
+    const scrappedData = [];
+    for (const promotion of promotionList) {
+      scrappedData.push(
+        JSON.stringify({
+          url: appendHttps(
+            await promotion.$eval('a[href]', (card) => card.getAttribute('href')),
+          ),
+          image: await promotion.$eval('img[src]', (img) =>
+            img.getAttribute('src'),
+          ),
+          title: getTitle(
+            await promotion.$eval('a[data-gtm-label]', (card) =>
+              card.getAttribute('data-gtm-label'),
+            ),
+          ),
+          description: '',
+        }),
+      );
+    }
+    return Promise.all(scrappedData);
+  };
+
+  const run = async () => {
+    let promotions;
+
+    try {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.goto(URL);
+
+      promotions = await getAll(page);
+
+      await browser.close();
+    } catch (e) {
+      console.error(e);
+    }
+
+    return promotions;
+  };
+
+  return { run };
+})();
+
+const wemakepriceCrawlerSaveAll = async () => {
+  const promotions = await wemakepriceCrawler.run();
+
+  await createAll(promotions, 5);
+};
+
+module.exports = { wemakepriceCrawlerSaveAll };

--- a/service/promotionService.js
+++ b/service/promotionService.js
@@ -1,17 +1,16 @@
-const promotion = require('../models/Promotion.js');
-const { Promotion } = require('../models');
+const Promotion = require('../models/Promotion.js');
 
 const findAll = () => {
-  return promotion.findAll();
+  return Promotion.findAll();
 };
 
 const findByBrand = (brandId) => {
-  return promotion.findAll({
+  return Promotion.findAll({
     where: { brand_id: brandId },
   });
 };
 
-const bulkCreate = async (promotions, brandId) => {
+const createAll = async (promotions, brandId) => {
   const savedPromotions = promotions.forEach((promotion) => {
     const promotionJson = JSON.parse(promotion);
 
@@ -36,5 +35,5 @@ const bulkCreate = async (promotions, brandId) => {
 module.exports = {
   findAll,
   findByBrand,
-  bulkCreate
+  createAll,
 };


### PR DESCRIPTION
## 제목
소셜커머스 크롤링 데이터 DB 저장 로직 구현

## 내용
쿠팡, 11번가, G마켓, 티몬, 위메프 - 5개 사이트의 기획전/이벤트 정보를 크롤링 후 DB에 저장하는 로직을 구현했습니다.
기존의 의류 크롤링 코드와 유사한 구조로 구현해봤습니다.